### PR TITLE
feat: Elastic Search  엘라스틱서치를 이용한 판매 등록한 물품 조회 기능 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ application.yml
 ### application config ###
 src/main/resources/**/*.yml
 src/main/resources/**/*.properties
+
+src/main/resources/service_account_key.json

--- a/Docker-Compose.yml
+++ b/Docker-Compose.yml
@@ -1,6 +1,9 @@
 
 services:
   es:
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: docker.elastic.co/elasticsearch/elasticsearch:8.17.4
     container_name: es
     environment:

--- a/Docker-Compose.yml
+++ b/Docker-Compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   es:

--- a/Docker-Compose.yml
+++ b/Docker-Compose.yml
@@ -1,0 +1,39 @@
+version: '3.8'
+
+services:
+  es:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.4
+    container_name: es
+    environment:
+      - node.name=es-node
+      - cluster.name=search-cluster
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+      - xpack.security.enabled=false
+      - xpack.security.http.ssl.enabled=false
+      - xpack.security.transport.ssl.enabled=false
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - es-data:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200 # https
+      - 9300:9300 #tcp
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.17.4
+    container_name: kibana
+    environment:
+      SERVER_NAME: kibana
+      ELASTICSEARCH_HOSTS: http://es:9200
+    ports:
+      - 5601:5601
+    depends_on:
+      - es
+
+volumes:
+  es-data:
+    driver: local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.17.4
+
+# Nori 플러그인 설치
+RUN elasticsearch-plugin install analysis-nori

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,8 @@ dependencies {
     // junit
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    //elasticsearch
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/palayo/config/ElasticSearchConfig.java
+++ b/src/main/java/com/example/palayo/config/ElasticSearchConfig.java
@@ -1,21 +1,33 @@
 package com.example.palayo.config;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.elasticsearch.client.ClientConfiguration;
-import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 
 @Configuration
 @EnableElasticsearchRepositories
-public class ElasticSearchConfig extends ElasticsearchConfiguration {
+public class ElasticSearchConfig {
     @Value("${spring.elasticsearch.uris}")
     private String host;
 
-    @Override
-    public ClientConfiguration clientConfiguration() {
-        return ClientConfiguration.builder()
-                .connectedTo(host)
-                .build();
+    @Bean
+    public RestClient restClient() {
+        return RestClient.builder(HttpHost.create(host)).build();
+    }
+
+    @Bean
+    public RestClientTransport transport() {
+        return new RestClientTransport(restClient(), new JacksonJsonpMapper());
+    }
+
+    @Bean
+    public ElasticsearchClient elasticsearchClient() {
+        return new ElasticsearchClient(transport());
     }
 }

--- a/src/main/java/com/example/palayo/config/ElasticSearchConfig.java
+++ b/src/main/java/com/example/palayo/config/ElasticSearchConfig.java
@@ -1,0 +1,21 @@
+package com.example.palayo.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories
+public class ElasticSearchConfig extends ElasticsearchConfiguration {
+    @Value("${spring.elasticsearch.uris}")
+    private String host;
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+                .connectedTo(host)
+                .build();
+    }
+}

--- a/src/main/java/com/example/palayo/config/SecurityConfig.java
+++ b/src/main/java/com/example/palayo/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
                 .logout(AbstractHttpConfigurer::disable)
                 .rememberMe(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(request -> request.getRequestURI().startsWith("/api")).permitAll()
+                        .requestMatchers(request -> request.getRequestURI().startsWith("/api/v1/auth")).permitAll()
                         .requestMatchers("/payment/**").permitAll()
                         .requestMatchers("/open").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/example/palayo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/palayo/domain/auth/controller/AuthController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.palayo.domain.auth.dto.request.SignupUserRequest;
 
 @RestController
-@RequestMapping("api")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/src/main/java/com/example/palayo/domain/elasticsearch/controller/ItemSearchController.java
+++ b/src/main/java/com/example/palayo/domain/elasticsearch/controller/ItemSearchController.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api")
+@RequestMapping("/api")
 public class ItemSearchController {
 
     private final ItemSearchService itemSearchService;

--- a/src/main/java/com/example/palayo/domain/elasticsearch/controller/ItemSearchController.java
+++ b/src/main/java/com/example/palayo/domain/elasticsearch/controller/ItemSearchController.java
@@ -1,0 +1,46 @@
+package com.example.palayo.domain.elasticsearch.controller;
+
+import com.example.palayo.common.dto.AuthUser;
+import com.example.palayo.common.response.Response;
+import com.example.palayo.domain.elasticsearch.dto.response.ItemSearchResponse;
+import com.example.palayo.domain.elasticsearch.service.ItemSearchService;
+import com.example.palayo.domain.item.enums.Category;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api")
+public class ItemSearchController {
+
+    private final ItemSearchService itemSearchService;
+
+    @GetMapping("/v1/items/search")
+    public Response<List<ItemSearchResponse>> searchItems(
+            @RequestParam String keyword,
+            @RequestParam(required = false) Category category,
+            @AuthenticationPrincipal AuthUser authUser,
+            Pageable pageable
+            )  {
+        Page<ItemSearchResponse> responses = itemSearchService.searchItems(keyword, category, authUser.getUserId(), pageable);
+        return Response.fromPage(responses);
+    }
+
+    @GetMapping("/v2/items/search")
+    public Response<List<ItemSearchResponse>> findBySellerId(
+            @AuthenticationPrincipal AuthUser authUser,
+            Pageable pageable
+    ) {
+        Page<ItemSearchResponse> responses = itemSearchService.findBySellerId(authUser.getUserId(), pageable);
+        return Response.fromPage(responses);
+    }
+}

--- a/src/main/java/com/example/palayo/domain/elasticsearch/controller/ItemSearchController.java
+++ b/src/main/java/com/example/palayo/domain/elasticsearch/controller/ItemSearchController.java
@@ -5,7 +5,6 @@ import com.example.palayo.common.response.Response;
 import com.example.palayo.domain.elasticsearch.dto.response.ItemSearchResponse;
 import com.example.palayo.domain.elasticsearch.service.ItemSearchService;
 import com.example.palayo.domain.item.enums.Category;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,8 +25,8 @@ public class ItemSearchController {
 
     @GetMapping("/v1/items/search")
     public Response<List<ItemSearchResponse>> searchItems(
-            @RequestParam String keyword,
-            @RequestParam(required = false) Category category,
+            @RequestParam (required = false) String keyword,
+            @RequestParam (required = false) Category category,
             @AuthenticationPrincipal AuthUser authUser,
             Pageable pageable
             )  {

--- a/src/main/java/com/example/palayo/domain/elasticsearch/document/ItemDocument.java
+++ b/src/main/java/com/example/palayo/domain/elasticsearch/document/ItemDocument.java
@@ -21,31 +21,20 @@ public class ItemDocument {
     @Id
     private Long id;
 
-    @Field(type = FieldType.Text)
     private String name;
 
-    @Field(type = FieldType.Text)
     private String content;
 
-    @Field(type = FieldType.Keyword)
     private Category category;
 
-    @Field(type = FieldType.Keyword)
-    private ItemStatus itemStatus;
-
-    @Field(type = FieldType.Text)
     private Long sellerId;
 
-    @Field(type = FieldType.Nested)
-    private List<ItemImage> itemImages = new ArrayList<>();
-
-    public static ItemDocument of(Long id, String name, String content, Category category, ItemStatus itemStatus, Long sellerId) {
+    public static ItemDocument of(Long id, String name, String content, Category category, Long sellerId) {
         ItemDocument item = new ItemDocument();
         item.id = id;
         item.name = name;
         item.content = content;
         item.category = category;
-        item.itemStatus = itemStatus;
         item.sellerId = sellerId;
         return item;
     }

--- a/src/main/java/com/example/palayo/domain/elasticsearch/document/ItemDocument.java
+++ b/src/main/java/com/example/palayo/domain/elasticsearch/document/ItemDocument.java
@@ -1,16 +1,13 @@
 package com.example.palayo.domain.elasticsearch.document;
 
+import com.example.palayo.domain.item.entity.Item;
 import com.example.palayo.domain.item.enums.Category;
 import com.example.palayo.domain.item.enums.ItemStatus;
-import com.example.palayo.domain.itemimage.entity.ItemImage;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.elasticsearch.annotations.*;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,13 +26,28 @@ public class ItemDocument {
 
     private Long sellerId;
 
-    public static ItemDocument of(Long id, String name, String content, Category category, Long sellerId) {
-        ItemDocument item = new ItemDocument();
-        item.id = id;
-        item.name = name;
-        item.content = content;
-        item.category = category;
-        item.sellerId = sellerId;
-        return item;
+    private ItemStatus itemStatus;
+
+    public static ItemDocument of(Item item) {
+        ItemDocument itemDocument = new ItemDocument();
+        itemDocument.id = item.getId();
+        itemDocument.name = item.getName();
+        itemDocument.content = item.getContent();
+        itemDocument.category = item.getCategory();
+        itemDocument.sellerId = item.getSeller().getId();
+        itemDocument.itemStatus = item.getItemStatus();
+        return itemDocument;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void updateCategory(Category category) {
+        this.category = category;
     }
 }

--- a/src/main/java/com/example/palayo/domain/elasticsearch/document/ItemDocument.java
+++ b/src/main/java/com/example/palayo/domain/elasticsearch/document/ItemDocument.java
@@ -1,0 +1,52 @@
+package com.example.palayo.domain.elasticsearch.document;
+
+import com.example.palayo.domain.item.enums.Category;
+import com.example.palayo.domain.item.enums.ItemStatus;
+import com.example.palayo.domain.itemimage.entity.ItemImage;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(indexName = "items")
+@Setting(settingPath = "elastic/item-setting.json")
+@Mapping(mappingPath = "elastic/item-mapping.json")
+public class ItemDocument {
+    @Id
+    private Long id;
+
+    @Field(type = FieldType.Text)
+    private String name;
+
+    @Field(type = FieldType.Text)
+    private String content;
+
+    @Field(type = FieldType.Keyword)
+    private Category category;
+
+    @Field(type = FieldType.Keyword)
+    private ItemStatus itemStatus;
+
+    @Field(type = FieldType.Text)
+    private Long sellerId;
+
+    @Field(type = FieldType.Nested)
+    private List<ItemImage> itemImages = new ArrayList<>();
+
+    public static ItemDocument of(Long id, String name, String content, Category category, ItemStatus itemStatus, Long sellerId) {
+        ItemDocument item = new ItemDocument();
+        item.id = id;
+        item.name = name;
+        item.content = content;
+        item.category = category;
+        item.itemStatus = itemStatus;
+        item.sellerId = sellerId;
+        return item;
+    }
+}

--- a/src/main/java/com/example/palayo/domain/elasticsearch/dto/response/ItemSearchResponse.java
+++ b/src/main/java/com/example/palayo/domain/elasticsearch/dto/response/ItemSearchResponse.java
@@ -1,0 +1,25 @@
+package com.example.palayo.domain.elasticsearch.dto.response;
+
+import com.example.palayo.domain.elasticsearch.document.ItemDocument;
+
+public record ItemSearchResponse (
+        Long id,
+        String name,
+        String content,
+        String category,
+        String ItemStatus,
+        Long sellerId
+) {
+    public static ItemSearchResponse of(ItemDocument item) {
+        return new ItemSearchResponse(
+                item.getId(),
+                item.getName(),
+                item.getContent(),
+                item.getCategory().name(),
+                item.getItemStatus().name(),
+                item.getSellerId()
+        );
+    }
+}
+
+

--- a/src/main/java/com/example/palayo/domain/elasticsearch/repository/ItemElasticSearchRepository.java
+++ b/src/main/java/com/example/palayo/domain/elasticsearch/repository/ItemElasticSearchRepository.java
@@ -1,0 +1,10 @@
+package com.example.palayo.domain.elasticsearch.repository;
+
+import com.example.palayo.domain.elasticsearch.document.ItemDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface ItemElasticSearchRepository extends ElasticsearchRepository<ItemDocument, Long> {
+    Page<ItemDocument> findBySellerId(Long sellerId, Pageable pageable);
+}

--- a/src/main/java/com/example/palayo/domain/elasticsearch/service/ItemSearchService.java
+++ b/src/main/java/com/example/palayo/domain/elasticsearch/service/ItemSearchService.java
@@ -1,0 +1,97 @@
+package com.example.palayo.domain.elasticsearch.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import com.example.palayo.domain.elasticsearch.document.ItemDocument;
+import com.example.palayo.domain.elasticsearch.dto.response.ItemSearchResponse;
+import com.example.palayo.domain.elasticsearch.repository.ItemElasticSearchRepository;
+import com.example.palayo.domain.item.enums.Category;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ItemSearchService {
+
+    private final ElasticsearchClient elasticsearchClient;
+    private final ItemElasticSearchRepository itemElasticSearchRepository;
+
+    public Page<ItemSearchResponse> searchItems(String keyword, Category category, Long sellerId, Pageable pageable) {
+        try {
+            // 쿼리 동적 구성
+            List<Query> mustQueries = new ArrayList<>();
+            List<Query> filterQueries = new ArrayList<>();
+
+            // keyword 검색 (name, content 둘 다)
+            if (keyword != null && !keyword.isBlank()) {
+                mustQueries.add(Query.of(q -> q
+                        .multiMatch(m -> m
+                                .fields("name", "content")
+                                .query(keyword)
+                        )
+                ));
+            }
+
+            // sellerId는 필수
+            filterQueries.add(Query.of(q -> q
+                    .term(t -> t.field("sellerId").value(sellerId))
+            ));
+
+            // 카테고리는 선택
+            if (category != null) {
+                filterQueries.add(Query.of(q -> q
+                        .term(t -> t.field("category").value(category.name()))
+                ));
+            }
+
+            // 전체 Bool 쿼리 조합
+            Query finalQuery = Query.of(q -> q
+                    .bool(b -> b
+                            .must(mustQueries)
+                            .filter(filterQueries)
+                    )
+            );
+
+            // 검색 실행
+            SearchResponse<ItemDocument> response = elasticsearchClient.search(s -> s
+                    .index("items")
+                    .query(finalQuery)
+                    .from((int) pageable.getOffset())
+                    .size(pageable.getPageSize()), ItemDocument.class);
+
+            // 결과 매핑
+            List<ItemSearchResponse> results = response.hits().hits().stream()
+                    .map(Hit::source)
+                    .filter(Objects::nonNull)
+                    .map(ItemSearchResponse::of)
+                    .toList();
+
+            long totalHits = response.hits().total() != null ? response.hits().total().value() : 0;
+
+            return new PageImpl<>(results, pageable, totalHits);
+
+        } catch (IOException e) {
+            log.error("엘라스틱서치 검색 실패", e);
+            return Page.empty(pageable); // 예외 시 빈 페이지 반환
+        }
+    }
+
+    public Page<ItemSearchResponse> findBySellerId(Long id, Pageable pageable) {
+        Page<ItemDocument> items = itemElasticSearchRepository.findBySellerId(id, pageable);
+
+        return items.map(ItemSearchResponse::of);
+    }
+}

--- a/src/main/java/com/example/palayo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/palayo/domain/user/controller/UserController.java
@@ -54,7 +54,7 @@ public class UserController {
     public Response<UserResponse> mypage(
             @AuthenticationPrincipal AuthUser authUser
     ) {
-        return Response.of(userService.mypage(authUser.getUserId()));
+        return Response.of(userService.myPage(authUser.getUserId()));
     }
 
      @GetMapping("v1/users/sold")

--- a/src/main/java/com/example/palayo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/palayo/domain/user/controller/UserController.java
@@ -15,7 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("api")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class UserController {
 

--- a/src/main/java/com/example/palayo/domain/user/service/UserService.java
+++ b/src/main/java/com/example/palayo/domain/user/service/UserService.java
@@ -75,7 +75,7 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public UserResponse mypage(Long userId) {
+    public UserResponse myPage(Long userId) {
         User user = findById(userId);
 
         return UserResponse.of(

--- a/src/main/resources/elastic/item-mapping.json
+++ b/src/main/resources/elastic/item-mapping.json
@@ -16,6 +16,10 @@
     },
     "sellerId": {
       "type": "long"
+    },
+    "itemStatus": {
+      "type": "keyword",
+      "index": false
     }
   }
 }

--- a/src/main/resources/elastic/item-mapping.json
+++ b/src/main/resources/elastic/item-mapping.json
@@ -1,0 +1,21 @@
+{
+  "properties": {
+    "id": {
+      "type": "long"
+    },
+    "name": {
+      "type": "text",
+      "analyzer": "nori_analyzer"
+    },
+    "content": {
+      "type": "text",
+      "analyzer": "nori_analyzer"
+    },
+    "category": {
+      "type": "keyword"
+    },
+    "sellerId": {
+      "type": "long"
+    }
+  }
+}

--- a/src/main/resources/elastic/item-setting.json
+++ b/src/main/resources/elastic/item-setting.json
@@ -1,0 +1,21 @@
+{
+  "analysis": {
+    "analyzer": {
+      "nori_analyzer": {
+        "type": "custom",
+        "tokenizer": "nori_tokenizer",
+        "filter": [
+          "lowercase",
+          "nori_part_of_speech",
+          "korean_stop"
+        ]
+      }
+    },
+    "filter": {
+      "korean_stop": {
+        "type": "stop",
+        "stopwords": "_korean_"
+      }
+    }
+  }
+}

--- a/src/test/java/com/example/palayo/dib/service/DibServiceTest.java
+++ b/src/test/java/com/example/palayo/dib/service/DibServiceTest.java
@@ -48,10 +48,16 @@ class DibServiceTest {
 
     @InjectMocks
     private DibService dibService;
-
+    @Mock
     private User user;
+
+    @Mock
     private Auction auction;
+
+    @Mock
     private AuthUser authUser;
+
+    @Mock
     private Item item;
 
     @BeforeEach

--- a/src/test/java/com/example/palayo/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/example/palayo/payment/service/PaymentServiceTest.java
@@ -6,6 +6,7 @@ import com.example.palayo.domain.payment.entity.Payment;
 import com.example.palayo.domain.payment.repostiory.PaymentRepository;
 import com.example.palayo.domain.payment.service.PaymentService;
 import com.example.palayo.domain.pointhistory.service.PointHistoriesService;
+import com.example.palayo.domain.user.enums.PointType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -70,7 +71,7 @@ public class PaymentServiceTest {
 
         //then
         verify(paymentRepository, times(1)).save(any(Payment.class));
-        verify(pointHistoriesService).chargePoints(metadata.getUserId(), amount);
+        verify(pointHistoriesService).updatePoints(metadata.getUserId(), amount, PointType.RECHARGE);
 
         assertThat(result).contains("결제 완료").contains("10000원");
     }


### PR DESCRIPTION
## 📌 What is this PR ?

엘라스틱서치를 이용한 item 다건 페이징 조회 기능 개발입니다.

<br/>

## 🔎 Additions / Changes

## Additions
v1의 경우 keyword, category를 검색 조건에 추가하여 검색의 범위를 좁힐 수 있는 동적쿼리가 적용된 검색 기능입니다.
v2의 경우는 sellerId로만 검색하는 추가 조건이 없는 간단한 검색 기능입니다. User 도메인의 myItem 메서드의 기능과 동일하지만 elasticsearch를 사용했다는 점만 다릅니다.

## Changes
User 도메인의 경우 카멜케이스를 지키기 위한 메서드명 변경 등이 있습니다.
Item 도메인의 경우 item 객체를 repository에 저장, 수정, 삭제를 할때 엘라스틱서치도 엘라스틱서치의 repository에 해당 내역이 반영 되게 코드가 삽입됐습니다.

<br/>

## 📷 Screenshot
![image](https://github.com/user-attachments/assets/1d5e5128-6c26-4b14-84cb-2afa5dc56ab0)
![image](https://github.com/user-attachments/assets/ab73a186-3d90-4de4-8f60-7eef9ada6580)

| 기능 | 스크린샷 |
| --- | --- |
| PNG | ![스크린샷](사진을 넣어주세요) |

<br/>

## ✅ Test Checklist
- [ ] 추가, 수정된 코드 부분에서
- [ ] 그의 테스트 체크한 내용을 작성해 주세요