### PR TITLE
feat : 판매한 물품, 구매한 물품 다건 조회로 api 변경 및 추가

### DIFF
--- a/src/main/java/com/example/palayo/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/example/palayo/domain/auction/repository/AuctionRepository.java
@@ -3,6 +3,7 @@ package com.example.palayo.domain.auction.repository;
 import java.util.List;
 import java.util.Optional;
 
+import com.example.palayo.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -31,4 +32,6 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 	List<Auction> findAllByStatusIn(List<AuctionStatus> statuses);
 
 	Optional<Auction> findByItemId(Long itemId);
+
+	Page<Auction> findByWinningBidder_Id(Long winningBidderId, Pageable pageable);
 }

--- a/src/main/java/com/example/palayo/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/example/palayo/domain/auction/service/AuctionService.java
@@ -68,7 +68,7 @@ public class AuctionService {
 		Auction savedAuction = auctionRepository.save(auction);
 
 		// 알림 예약 (경매 시작/종료 알림)
-		reserveMyAuctionNotification(savedAuction);
+//		reserveMyAuctionNotification(savedAuction);
 
 		return AuctionResponse.of(savedAuction);
 	}

--- a/src/main/java/com/example/palayo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/palayo/domain/user/controller/UserController.java
@@ -50,20 +50,29 @@ public class UserController {
         return Response.of(updatedPassword);
     }
 
-    @GetMapping("v1/users/mypage")
+    @GetMapping("v1/users/myPage")
     public Response<UserResponse> mypage(
             @AuthenticationPrincipal AuthUser authUser
     ) {
         return Response.of(userService.myPage(authUser.getUserId()));
     }
 
-     @GetMapping("v1/users/sold")
-     public Response<List<UserItemResponse>> sold(
+     @GetMapping("v1/users/soldItems")
+     public Response<List<UserItemResponse>> soldItems(
              @AuthenticationPrincipal AuthUser authUser,
              @RequestParam(defaultValue = "1") int page,
              @RequestParam(defaultValue = "10") int size
      ) {
-         return Response.fromPage(userService.myItem(authUser.getUserId(), page, size));
+         return Response.fromPage(userService.soldItems(authUser.getUserId(), page, size));
+     }
+
+     @GetMapping("v1/users/buyItems")
+     public Response<List<UserItemResponse>> buyItems(
+             @AuthenticationPrincipal AuthUser authUser,
+             @RequestParam(defaultValue = "1") int page,
+             @RequestParam(defaultValue = "10") int size
+     ){
+        return Response.fromPage(userService.buyItems(authUser.getUserId(), page, size));
      }
 
     @DeleteMapping("v1/users")

--- a/src/main/java/com/example/palayo/domain/user/service/UserService.java
+++ b/src/main/java/com/example/palayo/domain/user/service/UserService.java
@@ -2,6 +2,8 @@ package com.example.palayo.domain.user.service;
 
 import com.example.palayo.common.exception.BaseException;
 import com.example.palayo.common.exception.ErrorCode;
+import com.example.palayo.domain.auction.entity.Auction;
+import com.example.palayo.domain.auction.repository.AuctionRepository;
 import com.example.palayo.domain.item.entity.Item;
 import com.example.palayo.domain.item.repository.ItemRepository;
 import com.example.palayo.domain.user.dto.response.UserResponse;
@@ -17,6 +19,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -24,6 +28,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final ItemRepository itemRepository;
+    private final AuctionRepository auctionRepository;
 
     @Transactional
     public UserResponse updateNickname(String nickname, Long id) {
@@ -87,7 +92,7 @@ public class UserService {
     }
 
      @Transactional(readOnly = true)
-     public Page<UserItemResponse> myItem(Long id, int page, int size) {
+     public Page<UserItemResponse> soldItems(Long id, int page, int size) {
          User user = findById(id);
 
          Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
@@ -95,6 +100,15 @@ public class UserService {
 
          return items.map(UserItemResponse::of);
      }
+
+     @Transactional(readOnly = true)
+    public Page<UserItemResponse> buyItems(Long userId, int page, int size) {
+        User user = findById(userId);
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+        Page<Auction> auctions = auctionRepository.findByWinningBidder_Id(user.getId(), pageable);
+        return auctions.map(auction -> UserItemResponse.of(auction.getItem()));
+    }
 
     @Transactional
     public void delete(Long userId, String password) {

--- a/src/test/java/com/example/palayo/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/palayo/user/service/UserServiceTest.java
@@ -99,7 +99,7 @@ public class UserServiceTest {
 
     @Test
     @DisplayName("마이페이지 판매상품 조회 성공")
-    void myItemTest() {
+    void soldItemsTest() {
 
         Page<Item> itemPage = new PageImpl<>(Collections.singletonList(item));
         //given
@@ -110,7 +110,7 @@ public class UserServiceTest {
         )).willReturn(itemPage);
 
         //when
-        Page<UserItemResponse> result = userService.myItem(user.getId(), 1, 10);
+        Page<UserItemResponse> result = userService.soldItems(user.getId(), 1, 10);
 
         //then
         assertEquals(1, result.getTotalElements());


### PR DESCRIPTION
기존에 조회하던 코드는 판매한 물품 검색이며, 추가된 api는 구매한 물품 api입니다.

## 📌 What is this PR ?

기존의 MyItem은 판매한 물품민 검색이 가능했습니다.
따라서 구매한 물품 검색이 추가됐습니다.
buyMyItem메서드가 추가됐습니다.
<br/>

## 🔎 Additions / Changes

## Additions
buyMyItem이라는 메서드는 자신이 경매에서 낙찰한 물품을 다건 조회하는 기능입니다.
옥션에서 winning_bidder_id와 자신의 user_id를 비교한뒤(auctionRepository.findByWinningBidder_Id) 같다면 낙찰자라는 의미이니 auction 객체를 페이징처리하며 가져오고, 옥션 객체에서 아이템을 추출하여 반환합니다.

## Changes
구매한 물품 조회 기능이 생기게 되면서 MyItem 메서드는 SoldItem으로 이름이 변경 됐습니다.

<br/>

## 📷 Screenshot
해당 코드가 잘 실행되는 스크린샷을 남겨주세요

| 기능 | 스크린샷 |
| --- | --- |
| PNG | ![스크린샷](사진을 넣어주세요) |

<br/>

## ✅ Test Checklist
- [ ] 추가, 수정된 코드 부분에서
- [ ] 그의 테스트 체크한 내용을 작성해 주세요
