### PR TITLE
fix : 몽고 디비 추가로 인한 중복 포인트 증가 수정, 닉네임 변경 로직의 오류를 발견하여 수정

### DIFF
--- a/src/main/java/com/example/palayo/domain/pointhistory/mongo/service/PointHistoryService.java
+++ b/src/main/java/com/example/palayo/domain/pointhistory/mongo/service/PointHistoryService.java
@@ -30,7 +30,7 @@ public class PointHistoryService {
             throw new BaseException(ErrorCode.INSUFFICIENT_POINT, null);
         }
 
-        user.updatePointAmount(amount);
+//        user.updatePointAmount(amount);
 
         PointHistoryDocument pointHistory = PointHistoryDocument.builder()
                 .userId(userId)

--- a/src/main/java/com/example/palayo/domain/user/service/UserService.java
+++ b/src/main/java/com/example/palayo/domain/user/service/UserService.java
@@ -38,13 +38,11 @@ public class UserService {
             throw new BaseException(ErrorCode.NICKNAME_SAME_AS_OLD, nickname);
         }
 
-        User findByNicknameUser = userRepository.findByNickname(nickname)
-                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND, nickname)
+        userRepository.findByNickname(nickname).ifPresent(
+             foundUser -> {
+                 throw new BaseException(ErrorCode.DUPLICATE_NICNKNAME, nickname);
+             }
         );
-
-        if (!user.getId().equals(findByNicknameUser.getId())) {
-            throw new BaseException(ErrorCode.DUPLICATE_NICNKNAME, nickname);
-        }
 
         user.updateNickname(nickname);
 

--- a/src/test/java/com/example/palayo/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/palayo/user/service/UserServiceTest.java
@@ -9,11 +9,13 @@ import com.example.palayo.domain.user.dto.response.UserResponse;
 import com.example.palayo.domain.user.entity.User;
 import com.example.palayo.domain.user.repository.UserRepository;
 import com.example.palayo.domain.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -26,10 +28,8 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
@@ -43,7 +43,7 @@ public class UserServiceTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
-    @Mock
+    @Spy
     private User user;
 
     @Mock
@@ -52,17 +52,20 @@ public class UserServiceTest {
     @InjectMocks
     private UserService userService;
 
+    @BeforeEach
+    void setUp() {
+        User user = spy(User.of("email", "password", "nickname"));
+        ReflectionTestUtils.setField(user, "id", 1L);
+    }
+
     @Test
     @DisplayName("닉네임 변경 성공")
     void updateNickNameTest() {
         String newNickname = "newNickname";
 
         //given
-        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
-        given(user.getNickname())
-                .willReturn("oldNickname")  //처음에는 변경 전 닉네임이 나와야함
-                .willReturn(newNickname); //변경후에 getNickname() 호출시 변경 된 닉네임이 나와야함.
-        given(userRepository.findByNickname(newNickname)).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(userRepository.findByNickname(newNickname)).willReturn(Optional.empty());
 
         //when
         UserResponse response = userService.updateNickname(newNickname, user.getId());
@@ -82,7 +85,7 @@ public class UserServiceTest {
 
         //given
         ReflectionTestUtils.setField(user, "password", encodedPassword);
-        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(passwordEncoder.matches(newPassword, encodedPassword)).willReturn(false);
         given(passwordEncoder.matches(oldPassword, encodedPassword)).willReturn(true);
         given(passwordEncoder.encode(newPassword)).willReturn(encodedPassword);
@@ -124,7 +127,7 @@ public class UserServiceTest {
     void deleteTest() {
         //given
         ReflectionTestUtils.setField(user, "password", "test");
-        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
         given(passwordEncoder.matches("test", user.getPassword())).willReturn(true);
 
         //when


### PR DESCRIPTION
## 📌 What is this PR ?

몽고디비에서 유저에게 포인트를 증가하는 메서드 임시로 주석 처리

유저가 닉네임을 변경할때 검증하는 로직이 잘못되어 동작하지 않던 문제를 정상적으로 수정

닉네님 변경 로직의 변경에 따라 테스트 코드 또한 수정
<br/>

## 🔎 Additions / Changes

## Additions
새로운 기능이 추가되었다면 해당 내용에 대해 작성해 주세요 => Additions 으로 변경

## Changes
결제한 금액의 2배만큼 포인트 충전되던 문제가 발견됐었습니다.
 그 이유는 몽고디비의 로직과 jpa로직에서 각각 유저 객체의 updatePointAmount 메서드를 호출하여 2번 충전됐기 때문입니다.
따라서 임시로 몽고디비에서 해당 메서드 호출하는 부분을 주석처리했습니다.

닉네임 변경시 기존 로직에 오류가 있어 변경이 불가능한 로직을 수정했습니다.
이제 변경하려는 닉네임이 기존의 자신의 닉네임과 같거나 다른 유저의 닉네임과 같으면 변경이 불가능한 검증이 제대로 됩니다.

<br/>

## 📷 Screenshot
<img width="1470" alt="스크린샷 2025-04-18 오후 6 31 54" src="https://github.com/user-attachments/assets/35998767-1f71-41bf-82e7-54bf6354eff9" />

| 기능 | 스크린샷 |
| --- | --- |
| PNG | ![스크린샷](사진을 넣어주세요) |

<br/>

## ✅ Test Checklist
- [ ] 추가, 수정된 코드 부분에서
- [ ] 그의 테스트 체크한 내용을 작성해 주세요
