### PR TITLE
fix: 경매 낙찰 처리 시 상태 전환 및 보증금 예외 처리 개선

### DIFF
--- a/src/main/java/com/example/palayo/domain/auction/entity/Auction.java
+++ b/src/main/java/com/example/palayo/domain/auction/entity/Auction.java
@@ -35,12 +35,6 @@ import lombok.NoArgsConstructor;
 @EntityListeners(AuditingEntityListener.class)
 public class Auction {
 
-	// // Optimistic Lock 버전
-	// // 버전을 관리하여 동시성 충돌을 방지
-	// @Version
-	// @Column(name = "version")
-	// private Integer version;
-
 	// 경매 ID
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/palayo/domain/auction/entity/Auction.java
+++ b/src/main/java/com/example/palayo/domain/auction/entity/Auction.java
@@ -127,11 +127,16 @@ public class Auction {
 		this.currentPrice = newPrice;
 	}
 
-	// 경매 상태를 SUCCESS로 자동 설정
+	// 현재 시간으로 SUCCESS 처리
 	public void markAsSuccess(User winningBidder) {
+		this.markAsSuccess(winningBidder, LocalDateTime.now());
+	}
+
+	// 지정된 시간으로 SUCCESS 처리
+	public void markAsSuccess(User winningBidder, LocalDateTime successAt) {
 		this.status = AuctionStatus.SUCCESS;
 		this.winningBidder = winningBidder;
-		this.successAt = LocalDateTime.now(); // 낙찰 시점 기록
+		this.successAt = successAt; // 낙찰 시점 기록
 	}
 
 	// 경매 상태를 FAILED로 자동 설정

--- a/src/main/java/com/example/palayo/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/example/palayo/domain/auction/service/AuctionService.java
@@ -59,7 +59,7 @@ public class AuctionService {
 		// isInstantStart가 true일 경우, 즉시 시작 경매로 처리
 		if (Boolean.TRUE.equals(request.getIsInstantStart())) {
 			startedAt = LocalDateTime.now();
-			expiredAt = startedAt.plusMinutes(30);
+			expiredAt = request.getExpiredAt();
 			status = AuctionStatus.ACTIVE;
 		} else {
 			startedAt = request.getStartedAt();

--- a/src/main/java/com/example/palayo/domain/auction/service/AuctionServiceHelper.java
+++ b/src/main/java/com/example/palayo/domain/auction/service/AuctionServiceHelper.java
@@ -158,17 +158,22 @@ public class AuctionServiceHelper {
 			throw new BaseException(ErrorCode.NO_WINNING_BIDDER, "auctionId");
 		}
 
-		// 경매 상태를 SUCCESS로 변경
-		auction.markAsSuccess(auction.getWinningBidder());
+		// 낙찰 시점 분기 처리
+		LocalDateTime successTime = isBuyoutPriceReached(auction)
+			? LocalDateTime.now()               // 즉시 낙찰 → 입찰 시점 기준
+			: auction.getExpiredAt();           // 일반 낙찰 → 경매 종료 시간 기준
 
-		// 낙찰자 포인트 차감 및 보증금 사용 처리
+		// 상태 변경 및 낙찰자 설정
+		auction.markAsSuccess(auction.getWinningBidder(), successTime);
+
+		// 낙찰자 포인트 차감 및 보증금 처리
 		auctionHistoryServiceHelper.handleAuctionSuccess(
 			auction,
 			auction.getWinningBidder(),
 			auction.getCurrentPrice()
 		);
 
-		// 실패자 보증금 환불 처리
+		// 낙찰 실패자 보증금 환불
 		auctionHistoryServiceHelper.refundFailedBidders(auction);
 	}
 

--- a/src/main/java/com/example/palayo/domain/deposithistory/service/DepositHistoryService.java
+++ b/src/main/java/com/example/palayo/domain/deposithistory/service/DepositHistoryService.java
@@ -97,6 +97,11 @@ public class DepositHistoryService {
 	public void useDeposit(Long auctionId, Long userId) {
 		DepositHistory depositHistory = findDepositHistory(auctionId, userId);
 
+		// 이미 처리된 경우: 예외 대신 무시하고 return
+		if (depositHistory.getStatus() == DepositStatus.USED) {
+			return; // 중복 처리 방지
+		}
+
 		if (depositHistory.getStatus() != DepositStatus.PENDING) {
 			throw new BaseException(ErrorCode.INVALID_DEPOSIT_STATUS, "auctionId, userId");
 		}
@@ -108,6 +113,11 @@ public class DepositHistoryService {
 	@Transactional
 	public void refundDeposit(Long auctionId, Long userId) {
 		DepositHistory depositHistory = findDepositHistory(auctionId, userId);
+
+		// 이미 환불된 경우: 중복 처리 방지
+		if (depositHistory.getStatus() == DepositStatus.REFUNDED) {
+			return; // 아무 것도 안 하고 종료
+		}
 
 		if (depositHistory.getStatus() != DepositStatus.PENDING) {
 			throw new BaseException(ErrorCode.INVALID_DEPOSIT_STATUS, "auctionId, userId");


### PR DESCRIPTION
## 📌 What is this PR ?
경매 종료 시 상태 전환 및 보증금 관련 예외 처리를 개선하여, 낙찰 처리의 신뢰성과 안정성을 확보했습니다.  
즉시 낙찰과 일반 낙찰을 구분해 상태 업데이트 로직을 정리하고, 보증금 중복 처리로 인한 예외 상황도 방지했습니다.

<br/>

## 🔎 Additions / Changes

## Additions
새로운 기능이 추가되었다면 해당 내용에 대해 작성해 주세요 => Additions 으로 변경

## Changes
- 경매 종료 시 낙찰자가 존재하면 상태를 `SUCCESS`로 정상 전환되도록 수정
- 보증금 관련 `DepositHistory` 중복 처리로 발생하던 `INVALID_DEPOSIT_STATUS` 예외 방지
- `useDeposit()` 및 `refundDeposit()`의 중복 호출에 대한 안전성 강화
- 경매 상태 업데이트 로직에서 "즉시 낙찰"과 "일반 낙찰"을 명확히 분기 처리

<br/>

## 📷 Screenshot
해당 코드가 잘 실행되는 스크린샷을 남겨주세요

| 기능 | 스크린샷 |
| --- | --- |
| PNG | ![스크린샷](사진을 넣어주세요) |

<br/>

## ✅ Test Checklist
- [x] 낙찰자가 있는 경매 종료 시 상태가 SUCCESS로 정상 전환됨
- [x] 보증금 처리 시 중복 호출에 대한 예외가 발생하지 않음
- [x] 즉시 낙찰 / 일반 낙찰 각각에 대해 상태 업데이트가 정확히 동작함
