### PR TITLE
Refactor: Redis TTL 부여 로직 변경, Redis Key 구조 변경, Redis 조회 로직 변경

### DIFF
--- a/src/main/java/com/example/palayo/domain/dib/dto/response/DibRedisCacheResponse.java
+++ b/src/main/java/com/example/palayo/domain/dib/dto/response/DibRedisCacheResponse.java
@@ -6,7 +6,7 @@ import java.io.Serializable;
 
 @Getter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class DibRedisCacheResponse implements Serializable {

--- a/src/main/java/com/example/palayo/domain/dib/service/DibService.java
+++ b/src/main/java/com/example/palayo/domain/dib/service/DibService.java
@@ -10,20 +10,19 @@ import com.example.palayo.domain.dib.dto.response.DibRedisCacheResponse;
 import com.example.palayo.domain.dib.dto.response.DibResponse;
 import com.example.palayo.domain.dib.entity.Dib;
 import com.example.palayo.domain.dib.repository.DibRepository;
-import com.example.palayo.domain.notification.factory.RedisNotificationFactory;
-import com.example.palayo.domain.notification.service.NotificationService;
 import com.example.palayo.domain.user.entity.User;
 import com.example.palayo.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,12 +30,10 @@ public class DibService {
     private final DibRepository dibRepository;
     private final AuctionRepository auctionRepository;
     private final UserRepository userRepository;
-    private final NotificationService notificationService;
-    private final RedisNotificationFactory redisNotificationFactory;
     private final RedisTemplate<String, DibRedisCacheResponse> dibCacheRedisTemplate;
 
-    private String getCacheKey(Long userId) {
-        return "dib::" + userId;
+    private String getCacheKey(Long userId, Long auctionId) {
+        return "dib::" + userId + "::" + auctionId;
     }
 
     @Transactional
@@ -75,26 +72,18 @@ public class DibService {
 
         return DibResponse.of(dib);
     }
-//---------------------------------Redis----------------------------------------------------------------
 
     @Transactional
     public DibResponse toggleDib(AuthUser authUser, Long auctionId) {
         User user = getUserOrThrow(authUser);
-
         Auction auction = getAuctionOrThrow(auctionId);
-
         Optional<Dib> existingDib = findDib(user, auction);
 
-        String key = getCacheKey(authUser.getUserId());
+        String key = getCacheKey(user.getId(), auction.getId());
 
         if (existingDib.isPresent()) {
             dibRepository.delete(existingDib.get());
-            dibCacheRedisTemplate.opsForSet().remove(key,
-                    DibRedisCacheResponse.builder()
-                            .dibId(existingDib.get().getId())
-                            .userId(user.getId())
-                            .auctionId(auction.getId())
-                            .build());
+            dibCacheRedisTemplate.delete(key);
             return null;
         } else {
             Dib dib = dibRepository.save(Dib.of(user, auction));
@@ -105,45 +94,59 @@ public class DibService {
                     .auctionId(auction.getId())
                     .build();
 
-            dibCacheRedisTemplate.opsForSet().add(key, cacheDto);
-            dibCacheRedisTemplate.expire(key, Duration.ofDays(7));
+            dibCacheRedisTemplate.opsForValue().set(key, cacheDto);
+
+            LocalDateTime now = LocalDateTime.now();
+            Duration ttl = Duration.between(now, auction.getExpiredAt());
+
+            if (!ttl.isNegative() && !ttl.isZero()) {
+                dibCacheRedisTemplate.expire(key, ttl);
+            } else {
+                dibCacheRedisTemplate.expire(key, Duration.ofHours(1));
+            }
+
             return DibResponse.of(dib);
         }
     }
 
     @Transactional(readOnly = true)
     public Page<DibListResponse> redisGetMyDibs(AuthUser authUser, int page, int size) {
-        String key = getCacheKey(authUser.getUserId());
-        Set<DibRedisCacheResponse> cachedDibs = dibCacheRedisTemplate.opsForSet().members(key);
+        String pattern = "dib::" + authUser.getUserId() + "::*";
 
-        if (cachedDibs == null || cachedDibs.isEmpty()) {
-            return Page.empty();
-        }
+        List<String> keys = new ArrayList<>();
+        ScanOptions options = ScanOptions.scanOptions().match(pattern).build();
+        var cursor = dibCacheRedisTemplate.scan(options);
+        cursor.forEachRemaining(keys::add);
 
-        List<DibListResponse> dibList = cachedDibs.stream()
-                .sorted((a, b) -> b.getDibId().compareTo(a.getDibId()))
+        List<DibRedisCacheResponse> cacheDtos = dibCacheRedisTemplate.opsForValue().multiGet(keys);
+
+        List<DibListResponse> dibList = cacheDtos.stream()
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(DibRedisCacheResponse::getDibId).reversed())
                 .skip((long) page * size)
                 .limit(size)
                 .map(dto -> new DibListResponse(dto.getDibId(), dto.getUserId(), dto.getAuctionId()))
-                .toList();
+                .collect(Collectors.toList());
 
-        return new PageImpl<>(dibList, PageRequest.of(page, size), cachedDibs.size());
+        return new PageImpl<>(dibList, PageRequest.of(page, size), keys.size());
     }
 
     @Transactional(readOnly = true)
     public DibResponse redisGetMyDibById(AuthUser authUser, Long dibId) {
-        String key = getCacheKey(authUser.getUserId());
-        Set<DibRedisCacheResponse> cachedDibs = dibCacheRedisTemplate.opsForSet().members(key);
+        String pattern = "dib::" + authUser.getUserId() + "::*";
 
-        if (cachedDibs == null || cachedDibs.isEmpty()) {
-            throw new BaseException(ErrorCode.DIB_NOT_FOUND, authUser.getUserId().toString());
-        }
-        return cachedDibs.stream()
-                .filter(dib -> dib.getDibId().equals(dibId))
+        var cursor = dibCacheRedisTemplate.scan(ScanOptions.scanOptions().match(pattern).build());
+        List<String> keys = new ArrayList<>();
+        cursor.forEachRemaining(keys::add);
+
+        List<DibRedisCacheResponse> cacheDtos = dibCacheRedisTemplate.opsForValue().multiGet(keys);
+
+        return cacheDtos.stream()
+                .filter(Objects::nonNull)
+                .filter(dto -> dto.getDibId().equals(dibId))
                 .findFirst()
                 .map(dto -> new DibResponse(dto.getDibId(), dto.getUserId(), dto.getAuctionId()))
                 .orElseThrow(() -> new BaseException(ErrorCode.DIB_NOT_FOUND, dibId.toString()));
-
     }
 
     private User getUserOrThrow(AuthUser authUser) {


### PR DESCRIPTION
## 📌 What is this PR ?

Redis TTL 부여 로직 변경, Redis Key 구조 변경, Redis 조회 로직 변경

<br/>

## 🔎 Changes

## Changes

Redis에 Dib(찜) 데이터를 저장할 때,
처음에는 모든 경매에 대해 TTL을 일괄 7일로 설정함.

하지만 경매마다 종료 시간이 다르기 때문에,
굳이 7일을 유지할 필요가 없다는 문제가 발생

경매별 expiredAt(종료 시간)을 기준으로 남은 시간을 계산하여,
경매마다 다른 TTL을 부여하는 방식으로 수정함

기존 "dib::userId" 구조에서는 Set 안에 여러 경매가 섞여 있어
개별 경매마다 TTL을 다르게 설정할 수 없다는 한계를 발견하여
"dib::userId::auctionId" 형태로 Key를 분리 저장하는 구조로 변경함

<br/>

## 📷 Screenshot
해당 코드가 잘 실행되는 스크린샷을 남겨주세요

| 기능 | 스크린샷 |
| --- | --- |
| Key분리 저장 |![RedisTTL(경매종료시간설정)](https://github.com/user-attachments/assets/e75390ca-90e5-42b2-996f-4142e55e5f45) |
| 경매종료시간 | ![경매종료시간](https://github.com/user-attachments/assets/dd83db9b-9a86-474d-bade-6022ea18d6c5) |


<br/>

## ✅ Test Checklist
- [ ] 추가, 수정된 코드 부분에서
- [ ] 그의 테스트 체크한 내용을 작성해 주세요
